### PR TITLE
Use forked tarball and omit sha1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+cabocha-without-iconv
+=====================
+
+You can use this repo to install cabocha with linuxbrew.
+
+# Usage
+
+```
+brew tap masawada/cabocha-without-iconv
+brew install cabocha-without-iconv
+```
+
+# License
+
+Code is under the BSD 2-clause "Simplified" License.
+
+Notice:
+`cabocha-without-iconv.rb` is patched version of [cabocha.rb](https://github.com/Homebrew/homebrew-core/blob/master/Formula/cabocha.rb).
+[Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core) is under the [BSD 2-clause "Simplified" License](https://github.com/Homebrew/homebrew-core/blob/master/LICENSE.txt).

--- a/cabocha-without-iconv.rb
+++ b/cabocha-without-iconv.rb
@@ -4,12 +4,6 @@ class CabochaWithoutIconv < Formula
   url "https://github.com/masawada/cabocha/archive/0.69.tar.gz"
   sha256 "4630237c0f8db791a1da3f4b2da42c1b2e27fa9257025ec7ad79b7935ebffaa0"
 
-  bottle do
-    sha1 "c6d6a98dedfe7466c454101174b3d5cbc2752f9b" => :yosemite
-    sha1 "de55a785d8dcce5696a36f69b67168c913405259" => :mavericks
-    sha1 "40106c50d68d5bd03941946378679ff490ae679a" => :mountain_lion
-  end
-
   depends_on "crf++"
   depends_on "mecab"
 

--- a/cabocha-without-iconv.rb
+++ b/cabocha-without-iconv.rb
@@ -1,8 +1,8 @@
 class CabochaWithoutIconv < Formula
   desc "Yet Another Japanese Dependency Structure Analyzer"
   homepage "https://taku910.github.io/cabocha/"
-  url "https://googledrive.com/host/0B4y35FiV1wh7cGRCUUJHVTNJRnM/cabocha-0.69.tar.bz2"
-  sha256 "9db896d7f9d83fc3ae34908b788ae514ae19531eb89052e25f061232f6165992"
+  url "https://github.com/masawada/cabocha/archive/0.69.tar.gz"
+  sha256 "4630237c0f8db791a1da3f4b2da42c1b2e27fa9257025ec7ad79b7935ebffaa0"
 
   bottle do
     sha1 "c6d6a98dedfe7466c454101174b3d5cbc2752f9b" => :yosemite


### PR DESCRIPTION
fixes #1 

---

This p-r contains below changes.

- Use forked tarball instead of hosted on Google Drive
- Omit sha1
  - `bottled` section is useless on linuxbrew
- add README and specify about the license

plz review it @KOBA789